### PR TITLE
Fixed calculation of free disk space for unpriviliged user

### DIFF
--- a/helper.c
+++ b/helper.c
@@ -100,7 +100,7 @@ unsigned long long freespace(char *path) {
 		printf("Failed to get free disk space on %s\n", path);
 		return 0;
 	}
-	return (unsigned long long)fData.f_bsize * fData.f_bfree;
+	return (unsigned long long)fData.f_bsize * fData.f_bavail;
 }
 
 // Free memory. Taken from http://stackoverflow.com/questions/2513505/how-to-get-available-memory-c-g


### PR DESCRIPTION
Good day!
This change fixes a preallocation, previously amount of free space available to superuser was returned by freespace() function. But space actually available to a unprivileged user is smaller, this behavior lead to allocating of a file too big to fit a volume. That was the case on my mining/plotting machine. This change fixes that.

Regards,
Kristian Popov