### PR TITLE
Various usability improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ rico666 <bots@cryptoguru.org>                 (Don't donate)
   -a
     Flag to use asynchronous writing mode. If this is set, the plotter can work
     even while data is being written to disk. It will give you more speed at the
-    cost of more memory usage (will use double the memory!). Dafult is OFF.
+    cost of more memory usage (will use double the memory!). Default is OFF.
+
+  -b <maxmemory>
+    Maximum amount of memory to use. Will automatically be halved when used in
+    combination with -a.
 
   -R
     Resume from last position in an existing plot file.
@@ -101,8 +105,8 @@ If you do not match these numbers, the plotter will refuse to work for SSE4 and 
 cores, the default core will work on any arbitrary number of nonces.
 
 
-For \<startnonce>, \<staggersize> and \<nonces> you can either define just a number or
-add the T/t, G/g, M/m or K/k suffix. E.g. "-s 1234k"
+For \<startnonce>, \<staggersize>, \<nonces> and \<maxmemory> you can either define
+just a number or add the T/t, G/g, M/m or K/k suffix. E.g. "-s 1234k"
 * K/k = 1024
 * M/m = 1024<sup>2</sup>
 * G/g = 1024<sup>3</sup>

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ the code base until the result was what you see here.
     Niksa Franceschi <niksa.franceschi@gmail.com> (BURST-RQW7-3HNW-627D-3GAEV)
     a.k.a Mirkic7 <mirkic7@hotmail.com>
     Peter Kristolaitis <alter3d@alter3d.ca>       (BURST-WQ52-PUBY-N9WB-6J3DY)
+    Brynjar Eide <brynjar@segfault.no>            (BURST-5WLT-TP7V-6B7S-CZRQP)
 
 and finally
 
@@ -98,7 +99,7 @@ rico666 <bots@cryptoguru.org>                 (Don't donate)
 
 ###### Notes
 
-Calling the programm with wrong or incomplete command line, will print a rudimentary
+Calling the program with wrong or incomplete command line, will print a rudimentary
 usage information.
 
 The file name will have a '.plotting' suffix while the file is incomplete, and then

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ If you do not match these numbers, the plotter will refuse to work for SSE4 and 
 cores, the default core will work on any arbitrary number of nonces.
 
 
-For \<startnonce>, \<staggersize>, \<nonces>, \<maxmemory>, \<plotfilesizez> and
+For \<startnonce>, \<staggersize>, \<nonces>, \<maxmemory>, \<plotfilesize> and
 \<diskspace> you can either define just a number or add the T/t, G/g, M/m or K/k suffix.
 E.g. "-s 1234k"
 * K/k = 1024

--- a/README.md
+++ b/README.md
@@ -63,23 +63,27 @@ rico666 <bots@cryptoguru.org>                 (Don't donate)
     less I/O is necessary. If not given, the program tries to use 80% of the free
     memory of the machine. Please be aware that in combination with the -a parameter
     the memory requirement is doubled!
-    
+
   -n <nonces|spacedef>
     The number of nonces to plot. Each nonce is 256KB in size. If you do not
     give the number of nonces, the program will try to plot the maximum number
     of nonces that are possible according to the free disk space where
     <directory> resides.
-    
+
+  -p <plotfilesize>
+    Attempt to create a plot file of this size. May not be combined with -n, since
+    the amount of nonces will be calculated from the file size.
+
   -s <startnonce>
     The offset from which to start plotting nonces. If not given, the program will
     simply choose an offset randomly.
-    
+
   -t <threads>
     Number of threads to use when plotting. There is no "more is better".
     Depending on the number of physical cores of your CPU, and the core
     (see below) used, there will be an optimum. Probably the number of physical
     cores your CPU has.
-    
+
   -x <core>
     Define which SHABAL256 hashing core to use. Possible values are:
       0 - default core (*)
@@ -91,14 +95,14 @@ rico666 <bots@cryptoguru.org>                 (Don't donate)
     AVX2 being roughly 4x faster than default. See also "Notes" below!
 
  ```
- 
+
 ###### Notes
 
 Calling the programm with wrong or incomplete command line, will print a rudimentary
 usage information.
 
 The file name will have a '.plotting' suffix while the file is incomplete, and then
-renamed to the standard format if plotting is successful. 
+renamed to the standard format if plotting is successful.
 
 AVX2/SSE4 usage: In order to achieve best performance, you must make sure that the
 number of nonces to plot will match the number of threads like this:
@@ -109,8 +113,9 @@ If you do not match these numbers, the plotter will refuse to work for SSE4 and 
 cores, the default core will work on any arbitrary number of nonces.
 
 
-For \<startnonce>, \<staggersize>, \<nonces>, \<maxmemory> and \<diskspace> you can
-either define just a number or add the T/t, G/g, M/m or K/k suffix. E.g. "-s 1234k"
+For \<startnonce>, \<staggersize>, \<nonces>, \<maxmemory>, \<plotfilesizez> and
+\<diskspace> you can either define just a number or add the T/t, G/g, M/m or K/k suffix.
+E.g. "-s 1234k"
 * K/k = 1024
 * M/m = 1024<sup>2</sup>
 * G/g = 1024<sup>3</sup>

--- a/README.md
+++ b/README.md
@@ -52,7 +52,11 @@ rico666 <bots@cryptoguru.org>                 (Don't donate)
     Which directory to use. You can give relative as well as absolute paths.
     If you omit this, plots are written into the 'plots' directory in the
     current path.
-    
+
+  -f <diskspace>
+    When -n is not specified, leave this much disk space while calculating number
+    of nonces to plot.
+
   -m <staggersize>
     In this version, you can think of this as the memory cache used by the program
     before a write to the disk is necessary. Obviously the more you give here, the
@@ -105,13 +109,14 @@ If you do not match these numbers, the plotter will refuse to work for SSE4 and 
 cores, the default core will work on any arbitrary number of nonces.
 
 
-For \<startnonce>, \<staggersize>, \<nonces> and \<maxmemory> you can either define
-just a number or add the T/t, G/g, M/m or K/k suffix. E.g. "-s 1234k"
+For \<startnonce>, \<staggersize>, \<nonces>, \<maxmemory> and \<diskspace> you can
+either define just a number or add the T/t, G/g, M/m or K/k suffix. E.g. "-s 1234k"
 * K/k = 1024
 * M/m = 1024<sup>2</sup>
 * G/g = 1024<sup>3</sup>
 * T/t = 1024<sup>4</sup>
-in which case the definition is not the number of nonces, but the memory used.
+in which case the definitions for \<staggersize> and \<nonces> are not the number of
+nonces, but the memory used.
 
 ### TODO:
 

--- a/plot.c
+++ b/plot.c
@@ -326,8 +326,8 @@ writecache(void *arguments) {
     percent = ((double)100 * lastrun / nonces);
 
     if (lastseconds) {
-        printf("\33[2K\r%5.2f%% done. %i nonces/second, %02i:%02i:%02i left [writing%s]",
-                percent, lastspeed, lasthours, lastminutes, lastseconds, (asyncmode) ? " asynchronously" : "");
+        printf("\33[2K\r%5.2f%% done. %i nonces per minute, %02i:%02i:%02i left [writing%s]",
+                percent, (lastspeed * 60), lasthours, lastminutes, lastseconds, (asyncmode) ? " asynchronously" : "");
     } else {
         printf("\33[2K\r%5.2f%% done. [writing%s]",
                 percent, (asyncmode) ? " asynchronously" : "");
@@ -359,7 +359,7 @@ writecache(void *arguments) {
     lastminutes    = remainder / 60;;
     lastseconds    = remainder % 60;
 
-    printf("\33[2K\r%5.2f%% done. %i nonces/second, %02i:%02i:%02i left", percent, lastspeed, lasthours, lastminutes, lastseconds);
+    printf("\33[2K\r%5.2f%% done. %i nonces per minute, %02i:%02i:%02i left", percent, (lastspeed * 60), lasthours, lastminutes, lastseconds);
     fflush(stdout);
 
     return NULL;

--- a/plot.c
+++ b/plot.c
@@ -50,6 +50,7 @@ uint64_t leavespace  = 0;
 uint64_t plotfilesize;
 uint64_t starttime;
 uint64_t run, lastrun, thisrun;
+int userleavespace;
 int lastspeed, lasthours, lastminutes, lastseconds;
 int ofd;
 
@@ -475,6 +476,7 @@ int main(int argc, char **argv) {
                 maxmemory = parsed;
                 break;
             case 'f':
+                userleavespace = 1;
                 leavespace = parsed;
                 break;
             case 'p':
@@ -543,7 +545,7 @@ int main(int argc, char **argv) {
     // No nonces specified. Calculate nonces based on disk space
     if (nonces == 0) {
         uint64_t fs = freespace(outputdir);
-        if (leavespace == 0 && plotfilesize == 0) {
+        if (plotfilesize == 0 && (leavespace == 0 && userleavespace != 1)) {
             // Neither plot file size nor remaining disk space is specified.
             // Leave maximum 1GB if available, or 50% of the remaining diskspace otherwise.
             leavespace = (fs > 1024*1024*1024) ? 1024 * 1024 * 1024 : fs * 0.5;
@@ -554,7 +556,7 @@ int main(int argc, char **argv) {
                     (double)plotfilesize / 1024 / 1024 / 1024, (double)leavespace / 1024 / 1024 / 1024, (double)fs / 1024 / 1024 / 1024);
             exit(1);
         }
-        if ((fs <= usespace) || ((usespace / NONCE_SIZE) < 1)) {
+        if ((fs < usespace) || ((usespace / NONCE_SIZE) < 1)) {
             printf("Not enough free space on device. Disk has %0.2f GB available, and we're configured to use %0.2f GB, leaving %0.2f GB.\n",
                     (double)fs / 1024 / 1024 / 1024, (double)usespace / 1024 / 1024 / 1024, (double)leavespace / 1024 / 1024 / 1024);
             exit(-1);

--- a/plot.c
+++ b/plot.c
@@ -279,7 +279,7 @@ work_i(void *x_void_ptr) {
                     (uint64_t)(i - startnonce + n + 2),
                     (uint64_t)(i - startnonce + n + 3));
         }
-        if (selecttype == 2) { // AVX2
+        else if (selecttype == 2) { // AVX2
             m256nonce(addr,
                     (i + n + 0), (i + n + 1), (i + n + 2), (i + n + 3),
                     (i + n + 4), (i + n + 5), (i + n + 6), (i + n + 7),


### PR DESCRIPTION
I've added a few new config options, error/status messages and auto-calculations, mostly to scratch a few itches I got while getting my feet wet with plotting, and figured someone else might find the changes helpful as well.

The new config options are `-b <maxmemory>` `-f <diskspace>` and `-p <plotfilesize>` (where -f specifies how much free space to *leave* on the disk), all of which are intended give the user easier control of how much disk space and memory they want to use.

As for the auto-calculations, there are two primary changes:

- Asyncmode will now automatically effectively halve the plot size, instead of doubling memory usage, to avoid swapping.
- Nonce count is automatically selected to make `noncesperthread` play nicely with the selected hashing core, while also respecting the stagger size. This also made it possible to simplify the nonce-method loop somewhat.

I've also added more precision to the progress report, and the nonces per minute and hours remaining are now still visible when writing to disk.

Example output showcasing some of the changes:
```
# Specifying an unsuitable / incompatible plot count for the selected hashing core
# (Nonces per minute / hours remaining will appear, and remain, after the initial calculation.)
$ ./plot64 -k <key> -x 1 -d /mnt/plots -s 60065602 -n 7508246 -b 60G -t 16 -a -R
Async mode set.
Using SSE4 core.
Number of nonces is not divisible by threads * 4, and will be adjusted when calculating stagger size.
Stagger size was set to 121088, based on available memory and selected hashing algorithm.
Adjusting nonces from 7508246 to 7507456 to comply with stagger size.
Creating plots for 7507456 nonces (60065602 to 67573058, 1832.88 GB) with stagger size 121088, using 60544.00 MB memory and 16 threads
Pre-allocating space for file (1968034545664 bytes)...
Done pre-allocating space.
74.19% done. 8100 nonces per minute, 04:14:08 left
```
```
# Filling the entire disk, leaving most other options to their default values.
$ ./plot64 -k <key> -x 1 -d /mnt/plots -s 0 -f 0 -a -R
Async mode set.
Using SSE4 core.
Number of nonces not specified. Attempting to create 7508224 nonces (1833.06 GB), leaving 0.00 GB remaining free space.
Stagger size was set to 96256, based on available memory and selected hashing algorithm.
Adjusting nonces from 7508224 to 7507968 to comply with stagger size.
Creating plots for 7507968 nonces (1688755471511580750 to 1688755471519088718, 1833.00 GB) with stagger size 96256, using 48128.00 MB memory and 32 threads
Pre-allocating space for file (1968168763392 bytes)...
Done pre-allocating space.
 5.13% done. 20400 nonces per minute, 05:53:52 left [writing asynchronously]
```

FWIW, I'm unable to test AVX2, due to old hardware, but the actual hashing code has not been touched. 
I've successfully submitted deadlines from SSE4-produced nonces, but the plot files have only been tested briefly and in a limited environment. Should anyone test the code and find any problems, I'd be happy to fix any errors I've introduced.

Otherwise, feel free to include, remove, disregard or edit any and all parts of the changes I've made, naturally including the README additions.

