### PR TITLE
Added printf the actual nonce state 

### DIFF
--- a/plot.c
+++ b/plot.c
@@ -317,8 +317,8 @@ m256nonce(uint64_t addr,
 
 void *
 work_i(void *x_void_ptr) {
-    uint64_t i = *(uint64_t *)x_void_ptr;
 
+	uint64_t i = *(uint64_t *)x_void_ptr;
     uint32_t n;
 
     for (n = 0; n < noncesperthread; n += noncearguments) {
@@ -340,10 +340,20 @@ work_i(void *x_void_ptr) {
             nonce(addr, (i + n), (uint64_t)(i - startnonce + n));
         }
 
-    	if (0 == i && verbose == 1){
-            printf("%u nonces done from %u nonces\r",n*threads,noncesperthread*threads);
-            fflush(stdout);
-        }
+        /*
+         * Print out the actual nonce plot state if -v mode is active
+         */
+    	if (verbose == 1)
+    	{
+           static unsigned int oldn = 1;
+
+           if(oldn != n)
+           {
+             oldn=n;
+             printf("Nonces %lu from %u nonces %2.2f %% done...\r\n",((uint64_t)(n*threads))+run,nonces,((float)((n*threads)+run)/(float)nonces)*100);
+             fflush(stdout);
+           }
+         }
 
     }
     return NULL;

--- a/plot.c
+++ b/plot.c
@@ -339,6 +339,12 @@ work_i(void *x_void_ptr) {
         else { // STANDARD
             nonce(addr, (i + n), (uint64_t)(i - startnonce + n));
         }
+
+    	if (0 == i && verbose == 1){
+            printf("%u nonces done from %u nonces\r",n*threads,noncesperthread*threads);
+            fflush(stdout);
+        }
+
     }
     return NULL;
 }
@@ -357,7 +363,7 @@ getMS() {
 /* {{{ usage */
 
 void usage(char **argv) {
-    printf("Usage: %s -k KEY [ -x CORE ] [-d DIRECTORY] [-s STARTNONCE] [-n NONCES] [-m STAGGERSIZE] [-t THREADS] [-b MAXMEMORY] [-p PLOTFILESIZE] [-a] [-R]\n\n", argv[0]);
+    printf("Usage: %s -k KEY [ -x CORE ] [-v VERBOSE] [-d DIRECTORY] [-s STARTNONCE] [-n NONCES] [-m STAGGERSIZE] [-t THREADS] [-b MAXMEMORY] [-p PLOTFILESIZE] [-a] [-R]\n\n", argv[0]);
     printf("   see README.md\n");
     exit(-1);
 }
@@ -374,7 +380,7 @@ writecache(void *arguments) {
     percent = ((double)100 * lastrun / nonces);
 
     if (lastseconds) {
-        printf("\33[2K\r%5.2f%% done. %i nonces per minute, %02i:%02i:%02i left [writing%s]",
+        printf("\r\n\33[2K\r%5.2f%% done. %i nonces per minute, %02i:%02i:%02i left [writing%s]",
                 percent, (lastspeed * 60), lasthours, lastminutes, lastseconds, (asyncmode) ? " asynchronously" : "");
     } else {
         printf("\33[2K\r%5.2f%% done. [writing%s]",
@@ -407,7 +413,7 @@ writecache(void *arguments) {
     lastminutes    = remainder / 60;;
     lastseconds    = remainder % 60;
 
-    printf("\33[2K\r%5.2f%% done. %i nonces per minute, %02i:%02i:%02i left", percent, (lastspeed * 60), lasthours, lastminutes, lastseconds);
+    printf("\r\n\33[2K\r%5.2f%% done. %i nonces per minute, %02i:%02i:%02i left", percent, (lastspeed * 60), lasthours, lastminutes, lastseconds);
     fflush(stdout);
 
     return NULL;

--- a/plot.c
+++ b/plot.c
@@ -317,7 +317,6 @@ m256nonce(uint64_t addr,
 
 void *
 work_i(void *x_void_ptr) {
-
 	uint64_t i = *(uint64_t *)x_void_ptr;
     uint32_t n;
 
@@ -340,20 +339,18 @@ work_i(void *x_void_ptr) {
             nonce(addr, (i + n), (uint64_t)(i - startnonce + n));
         }
 
-        /*
-         * Print out the actual nonce plot state if -v mode is active
-         */
-    	if (verbose == 1)
-    	{
-           static unsigned int oldn = 1;
+        // If verbose mode is set print out actual nonce plot state
+		if (verbose == 1) {
+			static unsigned int oldn = 1;
 
-           if(oldn != n)
-           {
-             oldn=n;
-             printf("Nonces %lu from %u nonces %2.2f %% done...\r\n",((uint64_t)(n*threads))+run,nonces,((float)((n*threads)+run)/(float)nonces)*100);
-             fflush(stdout);
-           }
-         }
+			if (oldn != n) {
+				oldn = n;
+				printf("Nonces %lu from %u nonces %2.2f %% done...\r\n",
+						((uint64_t)(n * threads)) + run, nonces,
+						((float) ((n * threads) + run) / (float) nonces) * 100);
+				fflush(stdout);
+			}
+		}
 
     }
     return NULL;


### PR DESCRIPTION
I added when -v verbose mode is on that evertime in the thread the actual nonce state is printf to the stdout. This make sense for slow plotting devices like NAS drives. I plot my files on a NAS drive and it takes very long to get the feedback from writecache function.